### PR TITLE
enhancement: polishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "repository": "https://github.com/acrontum/filesystem-template",
   "description": "Filesystem templating engine and project scaffolding tool",
-  "main": "./dist/src/cli.js",
+  "main": "./dist/src/index.js",
   "bin": {
     "fst": "./dist/src/cli.js"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './cli';
 export * from './fst';
 export * from './lib';
+export * from './logging';

--- a/src/lib/recipe.ts
+++ b/src/lib/recipe.ts
@@ -121,7 +121,7 @@ export class Recipe implements RecipeSchema {
       this.logger.info(`'${script}' ${this.logger.ylw(this.scripts[script], { stream: process.stdout })}`);
 
       const options: ExecOptions = { cwd: cwd || '.' };
-      const proc = exec(this.scripts[script], options, (error, stdout) => (error ? reject({ error, stdout }) : resolve(stdout)));
+      const proc = exec(this.scripts[script], options, (error, stdout, stderr) => (error ? reject({ error, stdout, stderr }) : resolve(stdout)));
 
       if (this.logger.getLevel() > LogLevels.info) {
         proc.stdout.pipe(process.stdout);
@@ -203,7 +203,7 @@ export class Recipe implements RecipeSchema {
     this.scripts = schema.scripts;
     this.to = schema.to?.[0] === '/' ? schema.to : join(options.output || '.', schema.to || '.');
     this.previousOutput = options.previousOutput || process.cwd();
-    this.excludeDirs = (schema.excludeDirs || []).concat(options?.exclude);
+    this.excludeDirs = options?.exclude ? (schema.excludeDirs || []).concat(options.exclude) : schema.excludeDirs;
     this.includeDirs = schema.includeDirs;
     this.type = null;
 

--- a/src/lib/recipe.ts
+++ b/src/lib/recipe.ts
@@ -26,9 +26,6 @@ export interface RecipeOptions {
   output?: string;
   previousOutput?: string;
   exclude?: string[];
-  // include?: string[];
-  // cache?: boolean;
-  // parallel?: number;
 }
 
 export class Recipe implements RecipeSchema {

--- a/src/lib/recipe.ts
+++ b/src/lib/recipe.ts
@@ -4,7 +4,7 @@ import { join, resolve } from 'path';
 import { CliOptions } from '../cli';
 import { LoggingService, LogLevels } from '../logging';
 import { InvalidSchemaError } from './errors';
-import { fetchSource, generateVirtualFileTree, isRecipeFile, isRepo, SourceOptions } from './fs-utils';
+import { exists, fetchSource, generateVirtualFileTree, isRecipeFile, isRepo, SourceOptions } from './fs-utils';
 import { Renderer } from './renderer';
 
 export type RenderFunction = (recipe: Recipe, renderer: Renderer) => Promise<void> | void;
@@ -169,7 +169,7 @@ export class Recipe implements RecipeSchema {
     await this.runRecipeScript('before');
 
     if (typeof this.fileHandler === 'string') {
-      if (!existsSync(this.fileHandler)) {
+      if (!(await exists(this.fileHandler))) {
         await require(join(source, this.fileHandler))(this, renderer);
       } else {
         await require(this.fileHandler)(this, renderer);

--- a/src/lib/recipe.ts
+++ b/src/lib/recipe.ts
@@ -172,7 +172,7 @@ export class Recipe implements RecipeSchema {
       if (!(await exists(this.fileHandler))) {
         await require(join(source, this.fileHandler))(this, renderer);
       } else {
-        await require(this.fileHandler)(this, renderer);
+        await require(resolve(this.fileHandler))(this, renderer);
       }
     } else if (typeof this.fileHandler === 'function') {
       await this.fileHandler(this, renderer);

--- a/src/lib/renderer.ts
+++ b/src/lib/renderer.ts
@@ -25,13 +25,10 @@ export interface RenderOptions {
 }
 
 export class Renderer {
-  keyHandlers: Record<string, Handler[]> = {};
-  filenameHandlers: Record<string, Handler[]> = {};
   handlers: Handler[] = [];
   dest: string;
   root: VirtualFile;
   cache: Record<string, Function> = {};
-  env: Record<string, string> = {};
 
   constructor(root: VirtualFile, dest: string) {
     this.dest = dest;
@@ -93,7 +90,7 @@ export class Renderer {
    * @return {string}  Rendered template
    */
   renderAsTemplateString(template: string, templateVars: any = {}): string {
-    const data = { _indent: this.indent, ...this.env, ...templateVars };
+    const data = { _indent: this.indent, ...templateVars };
 
     const contentHash = createHash('md5').update(template).digest('base64');
 

--- a/src/lib/renderer.ts
+++ b/src/lib/renderer.ts
@@ -89,7 +89,7 @@ export class Renderer {
    *
    * @return {string}  Rendered template
    */
-  renderAsTemplateString(template: string, templateVars: any = {}): string {
+  renderAsTemplateString(template: string, templateVars: any = {}): Promise<string> {
     const data = { _indent: this.indent, ...templateVars };
 
     const contentHash = createHash('md5').update(template).digest('base64');
@@ -97,7 +97,7 @@ export class Renderer {
     if (!this.cache[contentHash]) {
       const params = Object.keys(data).join(', ');
       const indenter = typeof data._indent === 'function' ? '_indent' : '';
-      this.cache[contentHash] = new Function('data', `return ((${params}) => ${indenter}\`${template}\`)(...Object.values(data));`);
+      this.cache[contentHash] = new Function('data', `return (async (${params}) => ${indenter}\`${template}\`)(...Object.values(data));`);
     }
 
     return this.cache[contentHash](data);

--- a/src/lib/renderer.ts
+++ b/src/lib/renderer.ts
@@ -69,7 +69,7 @@ export class Renderer {
           }
 
           if (!node.outputs.length && !node.skip) {
-            await node.generateFileOrFolder();
+            await node.generateFiles();
           }
 
           node.resolve();

--- a/src/lib/virtual-file.ts
+++ b/src/lib/virtual-file.ts
@@ -123,10 +123,6 @@ export class VirtualFile {
   }
 
   getGenerationTargets(name?: string | PathGetter): string[] {
-    if (this.outputs.length) {
-      return this.outputs;
-    }
-
     const getFileName = this.getPathBuilder(name);
 
     return this.getPrevOut().map((out) => join(out, getFileName(out)));

--- a/src/lib/virtual-file.ts
+++ b/src/lib/virtual-file.ts
@@ -94,7 +94,7 @@ export class VirtualFile {
     return outputs;
   }
 
-  async generateFileOrFolder(name?: string | PathGetter): Promise<string[]> {
+  async generateFiles(name?: string | PathGetter): Promise<string[]> {
     logger.debug(`${this.name}: generate`);
     try {
       if (this.isDir) {

--- a/src/logging/logging.service.ts
+++ b/src/logging/logging.service.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 export const LogLevels = {
   none: 0,


### PR DESCRIPTION
- enh: add http fetch location handling; refactor virtual files 
- enh: always return targets from get targets 
- enh: export logging 
- enh: no default import 
- enh: remove unused options 
- enh: remove unused render vars 
- enh: rename vfile generate 
- enh: swap sync with quick async 
- fix: main export is index 
- fix: process exit only in main, barrell imports 
- fix: resolve handler path 
- fix: template render should be async
