### PR TITLE
fix: wait for dependents before searching for from/source

### DIFF
--- a/src/fst.ts
+++ b/src/fst.ts
@@ -15,12 +15,11 @@ const cleanup = async (tempDirs: string[], cache: boolean) => {
   await promises.rm(join(process.cwd(), '.fst'), { recursive: true, force: true });
 };
 
-let n = 0;
-
 const runBatch = (options: CliOptions, tempDirs: string[], logBuffer: LogBuffer, packageRoot: string) => (recipes: Recipe[], batch: Recipe[]) => {
   return batch.map(async (recipe) => {
     if (!recipe.parse()) {
       recipes.push(recipe);
+
       return false;
     }
 

--- a/src/lib/recipe.ts
+++ b/src/lib/recipe.ts
@@ -169,7 +169,6 @@ export class Recipe implements RecipeSchema {
   }
 
   hasPendingDependency(): boolean {
-    // console.log(this.depends, !!this.depends.find((dep) => !this.map[dep]?.generated));
     return !!this.depends.find((dep) => !this.map[dep]?.generated);
   }
 

--- a/src/lib/recipe.ts
+++ b/src/lib/recipe.ts
@@ -89,6 +89,7 @@ export class Recipe implements RecipeSchema {
     if (this.parsed) {
       return true;
     }
+
     this.parsed = true;
 
     if (!this.from) {
@@ -103,6 +104,10 @@ export class Recipe implements RecipeSchema {
 
     const fullSourcePath = resolve(this.from[0] === '/' ? this.from : join(this.previousOutput || '.', this.from));
     if (!existsSync(fullSourcePath)) {
+      if (this.hasPendingDependency()) {
+        return (this.parsed = false);
+      }
+
       const { recipes, ...rest } = this.toJSON();
       this.logger.error({ message: 'Source not found', recipe: rest });
       throw new InvalidSchemaError('Source not found');
@@ -163,8 +168,13 @@ export class Recipe implements RecipeSchema {
     return rest;
   }
 
+  hasPendingDependency(): boolean {
+    // console.log(this.depends, !!this.depends.find((dep) => !this.map[dep]?.generated));
+    return !!this.depends.find((dep) => !this.map[dep]?.generated);
+  }
+
   private async generate(options?: CliOptions & SourceOptions): Promise<string[]> {
-    if (this.depends.find((dep) => !this.map[dep]?.generated)) {
+    if (this.hasPendingDependency()) {
       return null;
     }
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -16,7 +16,7 @@ const flattenDependencies = (recipe: Recipe | RecipeSchema, dependencies: Depend
   return dependencies;
 };
 
-const assertValid = (
+const assertNotCircular = (
   deps: Record<string, string>,
   seen: Map<string, boolean>,
   dependencies: Dependencies,
@@ -37,16 +37,16 @@ const assertValid = (
     }
 
     seen.set(key, true);
-    assertValid(dependencies[key], seen, dependencies, alreadyValid);
+    assertNotCircular(dependencies[key], seen, dependencies, alreadyValid);
     seen.delete(key);
     alreadyValid[key] = true;
   }
 };
 
-export const validateRecipes = (recipes: Recipe[]) => {
+export const assertNoCircularDependencies = (recipes: Recipe[]) => {
   const dependencies: Dependencies = recipes.reduce((deps, node) => flattenDependencies(node, deps), {});
 
   for (const recipeName of Object.keys(dependencies)) {
-    assertValid(dependencies[recipeName], new Map([[recipeName, true]]), dependencies);
+    assertNotCircular(dependencies[recipeName], new Map([[recipeName, true]]), dependencies);
   }
 };


### PR DESCRIPTION
Fixes an issue where recipe parsing would throw `Source not found` when the source would be created by a recipe in `depends`.
