### PR TITLE
docs: rename package in quickstart section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acrontum/fst",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@acrontum/fst",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acrontum/fst",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "repository": "https://github.com/acrontum/filesystem-template",
   "description": "Filesystem templating engine and project scaffolding tool",
   "main": "./dist/src/index.js",

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 ## Usage
 
 Quickstart:  
-`npm install --save-dev @acrontum/filesystem-template`  
+`npm install --save-dev @acrontum/fst`  
 
 Basic usage:  
 `npx fst [options] <path_to_recipe_file>`


### PR DESCRIPTION
fix for npm and readme with new name